### PR TITLE
Switch to BUILDKITE_ANALYTICS_TOKEN to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Official JavaScript-based [Buildkite Test Analytics](https://buildkite.com/test-
 3) Run your tests locally:<br>
 
     ```js
-    env BUILDKITE_ANALYTICS_API_TOKEN=xyz npm test
+    env BUILDKITE_ANALYTICS_TOKEN=xyz npm test
     ```
 
-4) Add the `BUILDKITE_ANALYTICS_API_TOKEN` secret to your CI, push your changes to a branch, and open a pull request 🎉
+4) Add the `BUILDKITE_ANALYTICS_TOKEN` secret to your CI, push your changes to a branch, and open a pull request 🎉
 
     ```bash
     git checkout -b add-bk-test-analytics

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -11,7 +11,7 @@ describe('examples/jest', () => {
       cwd: path.join(__dirname, "../examples/jest"),
       env: {
         ...process.env,
-        BUILDKITE_ANALYTICS_API_TOKEN: "xyz",
+        BUILDKITE_ANALYTICS_TOKEN: "xyz",
         BUILDKITE_ANALYTICS_DEBUG_ENABLED: "true"
       }
     }

--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -12,7 +12,7 @@ const debug = (text) => {
 
 class JestBuildkiteAnalyticsReporter {
   constructor(globalConfig, options) {
-    this._buildkiteAnalyticsKey = process.env.BUILDKITE_ANALYTICS_API_TOKEN
+    this._buildkiteAnalyticsToken = process.env.BUILDKITE_ANALYTICS_TOKEN
     this._globalConfig = globalConfig
     this._options = options
     this._testResults = []
@@ -22,8 +22,8 @@ class JestBuildkiteAnalyticsReporter {
   }
 
   onRunComplete(test, results) {
-    if (!this._buildkiteAnalyticsKey) {
-      console.error('Missing BUILDKITE_ANALYTICS_API_TOKEN')
+    if (!this._buildkiteAnalyticsToken) {
+      console.error('Missing BUILDKITE_ANALYTICS_TOKEN')
       return
     }
 
@@ -34,7 +34,7 @@ class JestBuildkiteAnalyticsReporter {
     }
     let config = {
       headers: {
-        'Authorization': `Token token="${this._buildkiteAnalyticsKey}"`,
+        'Authorization': `Token token="${this._buildkiteAnalyticsToken}"`,
         'Content-Type': 'application/json'
       }
     }


### PR DESCRIPTION
The Ruby collectors use `BUILDKITE_ANALYTICS_TOKEN` — we should use the same for all collectors. This updates `BUILDKITE_ANALYTICS_API_TOKEN` to instead be `BUILDKITE_ANALYTICS_TOKEN`.

I also verified all the standard `BUILDKITE_ANALYTICS_URL` etc are the same, and they are 👍🏼