### PR TITLE
feat(jest collector): add option to only post failures

### DIFF
--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -112,4 +112,23 @@ describe('examples/jest', () => {
       done()
     })
   }, 10000) // 10s timeout
+
+  describe('when failuresOnly is true in reporter options', () => {
+    test('skips uploads for successful tests', (done) => {
+      exec('jest --config failuresOnly.config.js', { cwd, env }, (error, stdout, stderr) => {
+        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+
+        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const json = JSON.parse(jsonMatch[1])["data"]
+
+        // Uncomment to view the JSON
+        // console.log(json)
+
+        expect(json.data.length).toBe(1)
+        expect(json.data[0].result).toBe("failed")
+
+        done()
+      })
+    }, 10000) // 10s timeout
+  })
 })

--- a/examples/jest/failuresOnly.config.js
+++ b/examples/jest/failuresOnly.config.js
@@ -1,0 +1,12 @@
+const config = {
+  // Send results to Test Analytics
+  reporters: [
+    'default',
+    ['buildkite-test-collector/jest/reporter', { failuresOnly: true }]
+  ],
+
+  // Enable column + line capture for Test Analytics
+  testLocationInResults: true
+};
+
+module.exports = config;

--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -34,6 +34,7 @@ class JestBuildkiteAnalyticsReporter {
     const prefixedTestPath = this._paths.prefixTestPath(testResult.testFilePath);
 
     testResult.testResults.forEach((result) => {
+      if (this._options.failuresOnly && result.status !== 'failed') return
       let id = uuidv4()
       this._testResults.push({
         'id': id,


### PR DESCRIPTION
Had a use case where it was only preferable to upload failures. i.e.: For non-default branch runs, we only really want to see the failure details and aren't too interested in passing tests.

So, adding an option for this to the jest collector!

