### PR TITLE
Bump tmp to 0.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10114,9 +10114,9 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "engines": {
         "node": ">=14.14"
@@ -19815,9 +19815,9 @@
           "dev": true
         },
         "tmp": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-          "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+          "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
           "dev": true
         },
         "tmpl": {
@@ -24355,9 +24355,9 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true
     },
     "tmpl": {


### PR DESCRIPTION
Patches [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) / CVE-2026-44705 (high severity path traversal in tmp).

Bumps the transitive lockfile entry from `0.2.5` → `0.2.7` via the cypress dependency.

### Triage
- Transitive devDependency via `cypress` (used only in `examples/cypress`).
- Not used at runtime and not shipped in the published `buildkite-test-collector` package.
- Vulnerability requires attacker-controlled `prefix`/`postfix`/`dir` options to be passed to tmp, which doesn't occur in our usage.
- Cypress requires `tmp ~0.2.3`, so `0.2.7` satisfies the constraint.

### Verification
`npm ci` followed by `npm test` — all 64 tests across 10 suites pass locally.

Closes Dependabot alert #112.

### Related

- Resolves TE-6007