### PR TITLE
Decouple jasmine HTTP-instrumentation test from external endpoints

### DIFF
--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -84,7 +84,7 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("data[2].history.children[0].section", "http")
       expect(json).toHaveProperty("data[2].history.children[0].detail.lib", "http")
       expect(json).toHaveProperty("data[2].history.children[0].detail.method", "GET")
-      expect(json).toHaveProperty("data[2].history.children[0].detail.url", "buildkite.com/")
+      expect(json).toHaveProperty("data[2].history.children[0].detail.url", "127.0.0.1/")
 
       done()
     })

--- a/examples/jasmine/spec/example.spec.js
+++ b/examples/jasmine/spec/example.spec.js
@@ -1,4 +1,4 @@
-let axios = require('axios')
+let axios = require('axios'), http = require('http')
 var BuildkiteReporter = require('buildkite-test-collector/jasmine/reporter');
 var buildkiteReporter = new BuildkiteReporter(undefined, { tags: { hello: "jasmine" }});
 jasmine.getEnv().addReporter(buildkiteReporter);
@@ -15,7 +15,20 @@ describe('sum', () => {
   });
 })
 
-// Test instrumenting a HTTP request
-it('connects to buildkite.com', async () => {
-  const response = await axios.get('https://buildkite.com/')
+// Test instrumenting a HTTP request against a local server, so the test does
+// not depend on any external endpoint.
+it('instruments an HTTP request', async () => {
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end('ok')
+  })
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+  try {
+    const { port } = server.address()
+    await axios.get(`http://127.0.0.1:${port}/`)
+  } finally {
+    server.closeAllConnections()
+    await new Promise((resolve) => server.close(resolve))
+  }
 })


### PR DESCRIPTION
The `examples/jasmine` HTTP-instrumentation spec made a live request to `https://buildkite.com/` and the e2e test asserted the traced URL. That made an offline-capable collector test hostage to the live marketing site.

On 2026-06-17 the marketing site added an anonymous `/` → 302 → `/home/` redirect (confirmed in #chat-engineering). axios follows it, so the HTTP tracer ([util/network.js](https://github.com/buildkite/test-collector-javascript/blob/main/util/network.js) records `hostname + path` per underlying request) started recording `buildkite.com/home/`, breaking the assertion and CI.

### Changes

- Replace the external request with a throwaway local `http.Server` on `127.0.0.1:0` (ephemeral port). The tracer records hostname without the port, so the assertion is a stable `127.0.0.1/`.
- `closeAllConnections()` before `close()` so axios's kept-alive socket doesn't keep the spawned example process alive (which would hang the e2e exec).
- `http` required on the same line as `axios` to avoid shifting spec line numbers other `location` assertions depend on.

### Verification

- `npx jest e2e/jasmine.test.js` passes deterministically across repeated runs (previously 2 tests timed out against the live redirect).

### Deployment

Test/example-only change. No runtime impact.

### Rollback

Safe to revert — single commit touching only the jasmine example spec and its e2e test.