### PR TITLE
Force serialize-javascript >= 7.0.5 to fix RCE and DoS CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
     "": {
       "name": "buildkite-test-collector",
       "version": "1.9.7",
-      "dev": true,
       "license": "MIT",
       "workspaces": [
         "examples/jest",
@@ -9035,15 +9034,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.2.0",
       "dev": true,
@@ -9353,12 +9343,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
       "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {
@@ -18312,7 +18303,7 @@
             "log-symbols": "^4.1.0",
             "minimatch": "^5.1.6",
             "ms": "^2.1.3",
-            "serialize-javascript": "^6.0.2",
+            "serialize-javascript": "^7.0.5",
             "strip-json-comments": "^3.1.1",
             "supports-color": "^8.1.1",
             "workerpool": "^6.5.1",
@@ -18716,15 +18707,6 @@
             "side-channel": "^1.1.0"
           }
         },
-        "randombytes": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-          "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.0"
-          }
-        },
         "react": {
           "version": "18.2.0",
           "dev": true,
@@ -18938,13 +18920,10 @@
           "dev": true
         },
         "serialize-javascript": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-          "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-          "dev": true,
-          "requires": {
-            "randombytes": "^2.1.0"
-          }
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+          "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
+          "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
@@ -19192,7 +19171,7 @@
             "@jridgewell/trace-mapping": "^0.3.25",
             "jest-worker": "^27.4.5",
             "schema-utils": "^4.3.0",
-            "serialize-javascript": "^6.0.2",
+            "serialize-javascript": "^7.0.5",
             "terser": "^5.31.1"
           },
           "dependencies": {
@@ -22847,7 +22826,7 @@
         "log-symbols": "^4.1.0",
         "minimatch": "^5.1.6",
         "ms": "^2.1.3",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": "^7.0.5",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^6.5.1",
@@ -23251,15 +23230,6 @@
         "side-channel": "^1.1.0"
       }
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "react": {
       "version": "18.2.0",
       "dev": true,
@@ -23473,13 +23443,10 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
+      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -23727,7 +23694,7 @@
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": "^7.0.5",
         "terser": "^5.31.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "request-spy": "^0.0.10",
     "strip-ansi": "^6.0.0"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
+  },
   "devDependencies": {
     "@playwright/test": "^1.43.0",
     "jasmine": "^4.2.1",


### PR DESCRIPTION
## What

Adds an npm `overrides` entry forcing `serialize-javascript` to `^7.0.5` (resolves to 7.0.6) across the dependency tree.

## Why

`npm audit` flagged a **HIGH severity RCE/code-injection** vulnerability in `serialize-javascript <= 7.0.2`:

- **GHSA-5c6j-r48x-rmvq** (CVE-2020-7660 incomplete fix) — `RegExp.flags` and `Date.prototype.toISOString()` are interpolated into the serialized output without escaping, allowing code execution when the output is later `eval`'d. Patched in 7.0.3.
- **GHSA-qj8w-gfj5-8c6v** (CVE-2026-34043) — CPU-exhaustion DoS via crafted array-like objects, affecting `>= 5.0.0, < 7.0.5`. Patched in 7.0.5.

`serialize-javascript` is a **dev-only transitive dependency**, pulled in via `mocha` and via the cypress example's `webpack` → `terser-webpack-plugin`, both of which pin `^6.0.2`. Because the patched release is a major version (7.x), the parent ranges won't pick it up — so a plain lockfile bump is insufficient and an `overrides` entry is required.

7.x drops the `randombytes` dependency in favour of native `crypto`, hence its removal from the lockfile.

This is a devDependency only; it does **not** affect the published package's runtime dependencies (`axios`, `dotenv`, `request-spy`, `strip-ansi`).

## Scope

This addresses the `serialize-javascript` vulnerability that was identified but left out of scope by the form-data CVE fix in #150.

## Testing

- `npm audit` no longer reports `serialize-javascript` (0 HIGH remaining).
- Full `jest` suite passes — **64 tests across 10 suites**, including the `mocha` and `cypress` e2e tests that exercise this dependency (node 22.15.0).

Amp-Thread-ID: https://ampcode.com/threads/T-019eddaa-18d5-707f-b1d8-02b4e0ee75bd