### PR TITLE
Raise engines.npm to >=8.3.0 for overrides support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "url": "https://github.com/buildkite/test-collector-javascript.git"
   },
   "engines": {
-    "npm": ">=7.0.0"
+    "npm": ">=8.3.0"
   }
 }


### PR DESCRIPTION
## What

Raises the `engines.npm` constraint from `>=7.0.0` to `>=8.3.0`.

## Why

The `overrides` field added in #152 (forcing `serialize-javascript` to a non-vulnerable 7.x) is only honored by **npm >= 8.3.0**, the release that introduced `overrides`. With the previous `engines.npm` of `>=7.0.0`, an npm 7 install that regenerates the lockfile — or installs without the committed lockfile — silently ignores the override and resolves `serialize-javascript` back to the vulnerable `^6.0.2` via mocha and terser-webpack-plugin. That makes the security fix non-reproducible under the declared npm range.

This addresses the Codex review feedback left on #152 (which is already merged, hence a follow-up PR).

## Notes

- npm 8.3.0 shipped 2021-12-09 and is bundled with Node 16+, so every currently-supported Node line already exceeds this floor. Raising it is purely corrective metadata and does not change resolution.
- This is a devDependency-only concern; the published package's runtime dependencies are unaffected.

## Testing

- `npm ls serialize-javascript` confirms it still resolves to 7.0.6 with the override in effect.
- The change is metadata only; pre-existing mocha e2e failures on `main` are unrelated to it.

Amp-Thread-ID: https://ampcode.com/threads/T-019eddb8-f05b-711c-a139-c46b44ed0abc

### Related

- Follow-up to #152