### PR TITLE
1.9.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "buildkite-test-collector",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "lockfileVersion": 2,
   "requires": true,
   "dev": true,
   "packages": {
     "": {
       "name": "buildkite-test-collector",
-      "version": "1.9.7",
+      "version": "1.9.8",
       "license": "MIT",
       "workspaces": [
         "examples/jest",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "buildkite-test-analytics",
     "buildkite-test-collector"
   ],
-  "version": "1.9.7",
+  "version": "1.9.8",
   "homepage": "https://buildkite.com/platform/test-engine",
   "bugs": "https://github.com/buildkite/test-collector-javascript/issues",
   "license": "MIT",


### PR DESCRIPTION
## What

Version bump to **1.9.8** ahead of cutting the release.

## Changes since v1.9.7

- Force `serialize-javascript >= 7.0.5` to fix RCE and DoS CVEs (#152)
- Bump `form-data` 4.0.5 → 4.0.6 to fix CVE-2026-12143 (#151)
- Decouple jasmine HTTP-instrumentation test from external endpoints (#150)
- Bump `@babel/core` 7.20.12 → 7.29.6 (#149)

## Notes

Version bump only (`package.json` + `package-lock.json`). Follows the release process in the README.