### PR TITLE
Send test runner in the run_env payload

### DIFF
--- a/cypress/reporter.js
+++ b/cypress/reporter.js
@@ -6,7 +6,7 @@ const failureExpanded = require('../util/failureExpanded')
 // report errors.
 class CypressBuildkiteTestEngineReporter extends MochaBuildkiteTestEngineReporter {
   constructor(runner, options) {
-    super(runner, options)
+    super(runner, options, 'cypress')
   }
 
   testFinished(test) {

--- a/e2e/cypress.test.js
+++ b/e2e/cypress.test.js
@@ -64,6 +64,7 @@ describe('examples/cypress', () => {
       expect(json).toHaveProperty("run_env.key")
       expect(json).toHaveProperty("run_env.version")
       expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
+      expect(json).toHaveProperty("run_env.test_runner", "cypress")
 
       expect(json).toHaveProperty("tags", { "hello": "cypress" }) // examples/cypress/cypress.config.js
 

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -62,6 +62,7 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("run_env.key")
       expect(json).toHaveProperty("run_env.version")
       expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
+      expect(json).toHaveProperty("run_env.test_runner", "jasmine")
 
       expect(json).toHaveProperty("tags", { "hello": "jasmine" }) // examples/jasmine/spec/example.spec.js
 

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -69,6 +69,7 @@ describe('examples/jest', () => {
       expect(json).toHaveProperty("run_env.key")
       expect(json).toHaveProperty("run_env.version")
       expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
+      expect(json).toHaveProperty("run_env.test_runner", "jest")
 
       expect(json).toHaveProperty("tags", { "hello": "jest" }) // examples/jest/jest.config.js
 

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -69,6 +69,7 @@ describe('examples/mocha', () => {
       expect(json).toHaveProperty("run_env.key")
       expect(json).toHaveProperty("run_env.version")
       expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
+      expect(json).toHaveProperty("run_env.test_runner", "mocha")
 
       expect(json).toHaveProperty("tags", {"hello": "mocha"}) // examples/mocha/config.json
 

--- a/e2e/playwright.test.js
+++ b/e2e/playwright.test.js
@@ -60,6 +60,7 @@ describe('examples/playwright', () => {
     expect(data).toHaveProperty("run_env.key")
     expect(data).toHaveProperty("run_env.version")
     expect(data).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
+    expect(data).toHaveProperty("run_env.test_runner", "playwright")
 
     expect(data).toHaveProperty("data[0].scope", ' chromium example.spec.js has title')
     expect(data).toHaveProperty("data[0].name", 'has title')
@@ -114,6 +115,7 @@ describe('examples/playwright', () => {
       expect(data).toHaveProperty("run_env.key")
       expect(data).toHaveProperty("run_env.version")
       expect(data).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
+    expect(data).toHaveProperty("run_env.test_runner", "playwright")
 
       expect(data).toHaveProperty("data[0].scope", ' chromium example.spec.js has title')
       expect(data).toHaveProperty("data[0].name", 'has title')

--- a/e2e/vitest.test.js
+++ b/e2e/vitest.test.js
@@ -60,6 +60,7 @@ describe('examples/vitest', () => {
 			expect(json).toHaveProperty("run_env.key")
 			expect(json).toHaveProperty("run_env.version")
 			expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
+			expect(json).toHaveProperty("run_env.test_runner", "vitest")
 
 			expect(json).toHaveProperty("tags", { "hello": "vitest" }) // examples/vitest/vitest.config.js
 

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -41,7 +41,7 @@ class JasmineBuildkiteTestEngineReporter {
     this.config = config
     this._options = options
     this._testResults = []
-    this._testEnv = (new CI()).env();
+    this._testEnv = (new CI()).env('jasmine');
     this._tags = options?.tags;
     this._paths = new Paths(config, this._testEnv.location_prefix)
   }

--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -8,7 +8,7 @@ class JestBuildkiteTestEngineReporter {
     this._globalConfig = globalConfig
     this._options = options
     this._testResults = []
-    this._testEnv = (new CI()).env();
+    this._testEnv = (new CI()).env('jest');
     this._tags = options?.tags;
     this._paths = new Paths(globalConfig, this._testEnv.location_prefix)
   }

--- a/mocha/reporter.js
+++ b/mocha/reporter.js
@@ -18,10 +18,10 @@ const {
 } = Runnable.constants
 
 class MochaBuildkiteTestEngineReporter {
-  constructor(runner, options) {
+  constructor(runner, options, testRunner = 'mocha') {
     this._options = { token: process.env[`${options.reporterOptions.token_name}`]}
     this._testResults = []
-    this._testEnv = (new CI()).env();
+    this._testEnv = (new CI()).env(testRunner);
     this._tags = options.reporterOptions.tags;
     this._paths = new Paths({ cwd: process.cwd() }, this._testEnv.location_prefix)
 

--- a/playwright/reporter.js
+++ b/playwright/reporter.js
@@ -23,7 +23,7 @@ class PlaywrightBuildkiteTestEngineReporter {
 
   constructor(options) {
     this._testResults = [];
-    this._testEnv = (new CI()).env();
+    this._testEnv = (new CI()).env('playwright');
     this._tags = options?.tags;
     this._options = options;
     this._paths = new Paths({ cwd: process.cwd() }, this._testEnv.location_prefix);

--- a/util/ci.js
+++ b/util/ci.js
@@ -4,10 +4,10 @@ const { name, version } = require('../package.json')
 class CI {
   // the analytics env are more specific than the automatic ci platform env.
   // If they've been specified we'll assume the user wants to use that value instead.
-  env() {
+  env(testRunner) {
     return({
       ...this.ci_env(),
-      ...this.analytics_env()
+      ...this.analytics_env(testRunner)
     })
   }
 
@@ -33,7 +33,7 @@ class CI {
     }
   }
 
-  analytics_env() {
+  analytics_env(testRunner) {
     return this._stripUndefinedKeys({
       "key": process.env.BUILDKITE_ANALYTICS_KEY,
       "url": process.env.BUILDKITE_ANALYTICS_URL,
@@ -46,6 +46,7 @@ class CI {
       "location_prefix": process.env.BUILDKITE_ANALYTICS_LOCATION_PREFIX,
       "version": version,
       "collector": `js-${name}`,
+      "test_runner": testRunner,
     })
   }
 

--- a/util/ci.test.js
+++ b/util/ci.test.js
@@ -57,6 +57,18 @@ describe('CI.env', () => {
     expect(ci.env().location_prefix).toEqual('true')
   })
 
+  test('sets test_runner when passed to env', () => {
+    ci = new CI()
+
+    expect(ci.env('jest').test_runner).toEqual('jest')
+  })
+
+  test('omits test_runner when not passed to env', () => {
+    ci = new CI()
+
+    expect(ci.env().hasOwnProperty('test_runner')).toBeFalsy()
+  })
+
   test('generic CI env', () => {
     const envKeys = Object.keys(process.env)
     expect(envKeys).not.toContain('BUILDKITE_BUILD_ID')

--- a/vitest/reporter.js
+++ b/vitest/reporter.js
@@ -12,7 +12,7 @@ class VitestBuildkiteTestEngineReporter extends JsonReporter {
   constructor(options) {
     super(options);
     this._options = options;
-    this._testEnv = new CI().env();
+    this._testEnv = new CI().env('vitest');
     this._tags = options?.tags;
   }
 


### PR DESCRIPTION
Right now we can't tell which test framework a run came from once it hits Test Engine. This makes it hard to distinguish between jest, playwright, jasmine, mocha, and cypress runs.

This PR adds a `test_runner` field to the `run_env` payload, set per adapter (`jest`, `playwright`, `jasmine`, `mocha`, `cypress`, `vitest`). Cypress uses Mocha under the hood, so its reporter now explicitly passes `'cypress'` instead of inheriting Mocha's default.

This is additive and shouldn't require any changes on the customer's end, existing configs will just start sending the extra field once they upgrade.