### PR TITLE
[TE-6661] Bump js-yaml to patched versions (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
     "": {
       "name": "buildkite-test-collector",
       "version": "1.10.0",
-      "dev": true,
       "license": "MIT",
       "workspaces": [
         "examples/jest",
@@ -7711,9 +7710,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8477,9 +8476,9 @@
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -18000,9 +17999,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.15.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-          "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+          "version": "3.15.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+          "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -18415,9 +18414,9 @@
               }
             },
             "js-yaml": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-              "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+              "version": "4.3.1",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+              "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
               "dev": true,
               "requires": {
                 "argparse": "^2.0.1"
@@ -22531,9 +22530,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -22946,9 +22945,9 @@
           }
         },
         "js-yaml": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-          "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+          "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"


### PR DESCRIPTION
Dependabot [flagged a high severity DoS](https://github.com/buildkite/test-collector-javascript/security/dependabot/142) in `js-yaml` ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), CVSS 7.5). In 3.x and 4.x, `resolveYamlOmap()` checks for duplicate keys with a linear `indexOf` scan inside the per-element loop, so parsing an `!!omap` is O(n^2). A small YAML document can block the event loop for seconds. `!!omap` is in the default schema, so a plain `yaml.load()` is affected.

We had both vulnerable lines in the tree, each a transitive dev dependency:

```
jest > @jest/core > @jest/transform > babel-plugin-istanbul > @istanbuljs/load-nyc-config > js-yaml@3.15.0
mocha > js-yaml@4.3.0
```

Real risk here is low. We never parse untrusted YAML, and both copies are dev-only test tooling. Patching anyway to clear the alert.

This is a lockfile-only change. Both parents already declare ranges that allow the patched releases (`^3.13.1` and `^4.1.0`), so nothing was blocking the upgrade. The pinned resolutions just needed refreshing via `npm update js-yaml`, which lands them on 3.15.1 and 4.3.1. No `overrides` entry needed.

`npm audit` no longer lists `js-yaml`, and all 66 tests pass.

Fixes TE-6661

🤖 Generated with [Claude Code](https://claude.com/claude-code)