### PR TITLE
[TE-6674] Upgrade Cypress to remove vulnerable extract-zip

### DIFF
--- a/examples/cypress/package.json
+++ b/examples/cypress/package.json
@@ -10,7 +10,7 @@
     "@babel/preset-react": "^7.18.6",
     "babel-loader": "^9.1.0",
     "buildkite-test-collector": "file:../..",
-    "cypress": "^14.2.0",
+    "cypress": "^15.20.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "webpack": "^5.75.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,10 +43,595 @@
         "@babel/preset-react": "^7.18.6",
         "babel-loader": "^9.1.0",
         "buildkite-test-collector": "file:../..",
-        "cypress": "^14.2.0",
+        "cypress": "^15.20.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "webpack": "^5.75.0"
+      }
+    },
+    "examples/cypress/node_modules/@cypress/request": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.1.tgz",
+      "integrity": "sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~4.0.4",
+        "http-signature": "~1.4.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "performance-now": "^2.1.0",
+        "qs": "^6.15.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "^5.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
+    "examples/cypress/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/cypress/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "examples/cypress/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "examples/cypress/node_modules/arch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+      "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "examples/cypress/node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "examples/cypress/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "examples/cypress/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/cypress/node_modules/cli-table3": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "colors": "1.4.0"
+      }
+    },
+    "examples/cypress/node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/cypress/node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/cypress/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "examples/cypress/node_modules/cypress": {
+      "version": "15.20.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.20.1.tgz",
+      "integrity": "sha512-7GV3O7vQQG+EVVv9BGs6lCHY49x25jVi/z1+zdjuuq/o3eZeDwmGPJpRYnOWeGvQxTCtkydXWHBPhV8xuGXPLg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cypress/request": "^4.0.0",
+        "@cypress/xvfb": "^1.2.4",
+        "@types/sinonjs__fake-timers": "8.1.1",
+        "@types/sizzle": "^2.3.2",
+        "@types/tmp": "^0.2.3",
+        "arch": "^3.0.0",
+        "blob-util": "^2.0.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.7.1",
+        "cachedir": "^2.4.0",
+        "chalk": "^4.1.0",
+        "ci-info": "^4.1.0",
+        "cli-table3": "0.6.1",
+        "commander": "^6.2.1",
+        "common-tags": "^1.8.0",
+        "dayjs": "^1.10.4",
+        "debug": "^4.3.4",
+        "eventemitter2": "6.4.7",
+        "execa": "4.1.0",
+        "executable": "^4.1.1",
+        "fs-extra": "^9.1.0",
+        "hasha": "5.2.2",
+        "is-installed-globally": "~0.4.0",
+        "listr2": "^9.0.5",
+        "lodash": "^4.17.23",
+        "log-symbols": "^4.0.0",
+        "minimist": "^1.2.8",
+        "ospath": "^1.2.2",
+        "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
+        "proxy-from-env": "1.0.0",
+        "request-progress": "^3.0.0",
+        "supports-color": "^8.1.1",
+        "systeminformation": "^5.31.1",
+        "tmp": "~0.2.4",
+        "tree-kill": "1.2.2",
+        "untildify": "^4.0.0",
+        "yauzl": "^3.3.1"
+      },
+      "bin": {
+        "cypress": "bin/cypress"
+      },
+      "engines": {
+        "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "examples/cypress/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "examples/cypress/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "examples/cypress/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "examples/cypress/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/cypress/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "examples/cypress/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/cypress/node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "examples/cypress/node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/cypress/node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "examples/cypress/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "examples/cypress/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/cypress/node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/cypress/node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "examples/cypress/node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "examples/cypress/node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "examples/cypress/node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "examples/cypress/node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "examples/cypress/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "examples/cypress/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "examples/cypress/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "examples/cypress/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/cypress/node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "examples/jasmine": {
@@ -1759,55 +2344,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@cypress/request": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
-      "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
-      "dev": true,
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~4.0.4",
-        "http-signature": "~1.4.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "performance-now": "^2.1.0",
-        "qs": "~6.14.1",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "^5.0.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@cypress/request/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@cypress/xvfb": {
       "version": "1.2.4",
       "dev": true,
@@ -2700,6 +3236,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.28",
       "dev": true,
@@ -2712,15 +3255,6 @@
       "version": "21.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.0",
@@ -3038,18 +3572,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.12.0",
       "dev": true,
@@ -3147,25 +3669,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/arch": {
-      "version": "2.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "dev": true,
@@ -3201,19 +3704,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/async": {
-      "version": "3.2.4",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3565,14 +4055,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "dev": true,
@@ -3605,14 +4087,6 @@
     "node_modules/buildkite-test-collector-vitest-example": {
       "resolved": "examples/vitest",
       "link": true
-    },
-    "node_modules/cachedir": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -3716,14 +4190,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/check-more-types": {
-      "version": "2.24.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "dev": true,
@@ -3768,55 +4234,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-table3": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
-      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "dev": true,
@@ -3855,10 +4272,16 @@
       "version": "1.1.4",
       "license": "MIT"
     },
-    "node_modules/colorette": {
-      "version": "2.0.19",
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4751,149 +5174,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/cypress": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.0.tgz",
-      "integrity": "sha512-u7fuc9JEpSYLOdu8mzZDZ/JWsHUzR5pc8i1TeSqMz/bafXp+6IweMAeyphsEJ6/13qbB6nwTEY1m+GUAp6GqCQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@cypress/request": "^3.0.7",
-        "@cypress/xvfb": "^1.2.4",
-        "@types/sinonjs__fake-timers": "8.1.1",
-        "@types/sizzle": "^2.3.2",
-        "arch": "^2.2.0",
-        "blob-util": "^2.0.2",
-        "bluebird": "^3.7.2",
-        "buffer": "^5.7.1",
-        "cachedir": "^2.3.0",
-        "chalk": "^4.1.0",
-        "check-more-types": "^2.24.0",
-        "ci-info": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.5",
-        "commander": "^6.2.1",
-        "common-tags": "^1.8.0",
-        "dayjs": "^1.10.4",
-        "debug": "^4.3.4",
-        "enquirer": "^2.3.6",
-        "eventemitter2": "6.4.7",
-        "execa": "4.1.0",
-        "executable": "^4.1.1",
-        "extract-zip": "2.0.1",
-        "figures": "^3.2.0",
-        "fs-extra": "^9.1.0",
-        "getos": "^3.2.1",
-        "is-installed-globally": "~0.4.0",
-        "lazy-ass": "^1.6.0",
-        "listr2": "^3.8.3",
-        "lodash": "^4.17.21",
-        "log-symbols": "^4.0.0",
-        "minimist": "^1.2.8",
-        "ospath": "^1.2.2",
-        "pretty-bytes": "^5.6.0",
-        "process": "^0.11.10",
-        "proxy-from-env": "1.0.0",
-        "request-progress": "^3.0.0",
-        "semver": "^7.5.3",
-        "supports-color": "^8.1.1",
-        "tmp": "~0.2.3",
-        "tree-kill": "1.2.2",
-        "untildify": "^4.0.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "cypress": "bin/cypress"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      }
-    },
-    "node_modules/cypress/node_modules/ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cypress/node_modules/execa": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/cypress/node_modules/get-stream": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cypress/node_modules/human-signals": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/cypress/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cypress/node_modules/supports-color": {
-      "version": "8.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -5067,15 +5347,17 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/enquirer": {
-      "version": "2.3.6",
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
       "engines": {
-        "node": ">=8.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -5308,39 +5590,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -5366,36 +5615,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/fill-range": {
@@ -5546,6 +5765,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5598,14 +5830,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/getos": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^3.2.0"
       }
     },
     "node_modules/getpass": {
@@ -5734,6 +5958,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasha/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hasown": {
@@ -5895,14 +6146,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -7808,14 +8051,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/lazy-ass": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "dev": true,
@@ -8090,32 +8325,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/listr2": {
-      "version": "3.14.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rfdc": "^1.3.0",
-        "rxjs": "^7.5.1",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
-      },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -8170,52 +8379,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/loose-envify": {
@@ -8331,6 +8494,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -8741,20 +8917,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -9257,23 +9419,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/rfdc": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "dev": true,
@@ -9320,14 +9465,6 @@
         "@rolldown/binding-wasm32-wasi": "1.0.3",
         "@rolldown/binding-win32-arm64-msvc": "1.0.3",
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -9496,19 +9633,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -9689,6 +9813,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/systeminformation": {
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.1.tgz",
+      "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -9836,11 +9987,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9983,7 +10129,8 @@
     "node_modules/tslib": {
       "version": "2.4.1",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -10599,15 +10746,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {
@@ -11632,47 +11770,6 @@
       "version": "0.2.3",
       "dev": true
     },
-    "@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@cypress/request": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
-      "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~4.0.4",
-        "http-signature": "~1.4.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "performance-now": "^2.1.0",
-        "qs": "~6.14.1",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "^5.0.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
-        }
-      }
-    },
     "@cypress/xvfb": {
       "version": "1.2.4",
       "dev": true,
@@ -12285,6 +12382,12 @@
       "version": "2.0.1",
       "dev": true
     },
+    "@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "17.0.28",
       "dev": true,
@@ -12295,14 +12398,6 @@
     "@types/yargs-parser": {
       "version": "21.0.1",
       "dev": true
-    },
-    "@types/yauzl": {
-      "version": "2.10.0",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@vitest/expect": {
       "version": "4.1.0",
@@ -12564,14 +12659,6 @@
         "debug": "4"
       }
     },
-    "aggregate-error": {
-      "version": "3.1.0",
-      "dev": true,
-      "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      }
-    },
     "ajv": {
       "version": "8.12.0",
       "dev": true,
@@ -12626,10 +12713,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "arch": {
-      "version": "2.2.0",
-      "dev": true
-    },
     "argparse": {
       "version": "1.0.10",
       "dev": true,
@@ -12656,14 +12739,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true
-    },
-    "astral-regex": {
-      "version": "2.0.0",
-      "dev": true
-    },
-    "async": {
-      "version": "3.2.4",
       "dev": true
     },
     "asynckit": {
@@ -12886,10 +12961,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -13925,47 +13996,6 @@
           "version": "0.2.3",
           "dev": true
         },
-        "@colors/colors": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-          "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-          "dev": true,
-          "optional": true
-        },
-        "@cypress/request": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
-          "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~4.0.4",
-            "http-signature": "~1.4.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "performance-now": "^2.1.0",
-            "qs": "~6.14.1",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "^5.0.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^8.3.2"
-          },
-          "dependencies": {
-            "uuid": {
-              "version": "8.3.2",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-              "dev": true
-            }
-          }
-        },
         "@cypress/xvfb": {
           "version": "1.2.4",
           "dev": true,
@@ -14578,6 +14608,12 @@
           "version": "2.0.1",
           "dev": true
         },
+        "@types/tmp": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+          "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+          "dev": true
+        },
         "@types/yargs": {
           "version": "17.0.28",
           "dev": true,
@@ -14588,14 +14624,6 @@
         "@types/yargs-parser": {
           "version": "21.0.1",
           "dev": true
-        },
-        "@types/yauzl": {
-          "version": "2.10.0",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/node": "*"
-          }
         },
         "@vitest/expect": {
           "version": "4.1.0",
@@ -14857,14 +14885,6 @@
             "debug": "4"
           }
         },
-        "aggregate-error": {
-          "version": "3.1.0",
-          "dev": true,
-          "requires": {
-            "clean-stack": "^2.0.0",
-            "indent-string": "^4.0.0"
-          }
-        },
         "ajv": {
           "version": "8.12.0",
           "dev": true,
@@ -14919,10 +14939,6 @@
             "picomatch": "^2.0.4"
           }
         },
-        "arch": {
-          "version": "2.2.0",
-          "dev": true
-        },
         "argparse": {
           "version": "1.0.10",
           "dev": true,
@@ -14949,14 +14965,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
           "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-          "dev": true
-        },
-        "astral-regex": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "async": {
-          "version": "3.2.4",
           "dev": true
         },
         "asynckit": {
@@ -15180,10 +15188,6 @@
             "ieee754": "^1.1.13"
           }
         },
-        "buffer-crc32": {
-          "version": "0.2.13",
-          "dev": true
-        },
         "buffer-from": {
           "version": "1.1.2",
           "dev": true
@@ -15196,10 +15200,388 @@
             "@babel/preset-react": "^7.18.6",
             "babel-loader": "^9.1.0",
             "buildkite-test-collector": "file:../..",
-            "cypress": "^14.2.0",
+            "cypress": "^15.20.1",
             "react": "^18.2.0",
             "react-dom": "^18.2.0",
             "webpack": "^5.75.0"
+          },
+          "dependencies": {
+            "@cypress/request": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.1.tgz",
+              "integrity": "sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==",
+              "dev": true,
+              "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~4.0.4",
+                "http-signature": "~1.4.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "performance-now": "^2.1.0",
+                "qs": "^6.15.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "^5.0.0",
+                "tunnel-agent": "^0.6.0"
+              }
+            },
+            "ansi-escapes": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+              "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+              "dev": true,
+              "requires": {
+                "environment": "^1.0.0"
+              }
+            },
+            "ansi-regex": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+              "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "6.2.3",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+              "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+              "dev": true
+            },
+            "arch": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+              "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
+              "dev": true
+            },
+            "cachedir": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+              "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+              "dev": true
+            },
+            "ci-info": {
+              "version": "4.4.0",
+              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+              "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+              "dev": true
+            },
+            "cli-cursor": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+              "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+              "dev": true,
+              "requires": {
+                "restore-cursor": "^5.0.0"
+              }
+            },
+            "cli-table3": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+              "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+              "dev": true,
+              "requires": {
+                "colors": "1.4.0",
+                "string-width": "^4.2.0"
+              }
+            },
+            "cli-truncate": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+              "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+              "dev": true,
+              "requires": {
+                "slice-ansi": "^8.0.0",
+                "string-width": "^8.2.0"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "8.2.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+                  "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+                  "dev": true,
+                  "requires": {
+                    "get-east-asian-width": "^1.5.0",
+                    "strip-ansi": "^7.1.2"
+                  }
+                }
+              }
+            },
+            "colorette": {
+              "version": "2.0.20",
+              "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+              "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+              "dev": true
+            },
+            "cypress": {
+              "version": "15.20.1",
+              "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.20.1.tgz",
+              "integrity": "sha512-7GV3O7vQQG+EVVv9BGs6lCHY49x25jVi/z1+zdjuuq/o3eZeDwmGPJpRYnOWeGvQxTCtkydXWHBPhV8xuGXPLg==",
+              "dev": true,
+              "requires": {
+                "@cypress/request": "^4.0.0",
+                "@cypress/xvfb": "^1.2.4",
+                "@types/sinonjs__fake-timers": "8.1.1",
+                "@types/sizzle": "^2.3.2",
+                "@types/tmp": "^0.2.3",
+                "arch": "^3.0.0",
+                "blob-util": "^2.0.2",
+                "bluebird": "^3.7.2",
+                "buffer": "^5.7.1",
+                "cachedir": "^2.4.0",
+                "chalk": "^4.1.0",
+                "ci-info": "^4.1.0",
+                "cli-table3": "0.6.1",
+                "commander": "^6.2.1",
+                "common-tags": "^1.8.0",
+                "dayjs": "^1.10.4",
+                "debug": "^4.3.4",
+                "eventemitter2": "6.4.7",
+                "execa": "4.1.0",
+                "executable": "^4.1.1",
+                "fs-extra": "^9.1.0",
+                "hasha": "5.2.2",
+                "is-installed-globally": "~0.4.0",
+                "listr2": "^9.0.5",
+                "lodash": "^4.17.23",
+                "log-symbols": "^4.0.0",
+                "minimist": "^1.2.8",
+                "ospath": "^1.2.2",
+                "pretty-bytes": "^5.6.0",
+                "process": "^0.11.10",
+                "proxy-from-env": "1.0.0",
+                "request-progress": "^3.0.0",
+                "supports-color": "^8.1.1",
+                "systeminformation": "^5.31.1",
+                "tmp": "~0.2.4",
+                "tree-kill": "1.2.2",
+                "untildify": "^4.0.0",
+                "yauzl": "^3.3.1"
+              }
+            },
+            "emoji-regex": {
+              "version": "10.6.0",
+              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+              "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+              "dev": true
+            },
+            "eventemitter3": {
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+              "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+              "dev": true
+            },
+            "execa": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+              "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+              "dev": true,
+              "requires": {
+                "cross-spawn": "^7.0.0",
+                "get-stream": "^5.0.0",
+                "human-signals": "^1.1.1",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.0",
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2",
+                "strip-final-newline": "^2.0.0"
+              }
+            },
+            "get-stream": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+              "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+              "dev": true,
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            },
+            "human-signals": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+              "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+              "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+              "dev": true,
+              "requires": {
+                "get-east-asian-width": "^1.3.1"
+              }
+            },
+            "listr2": {
+              "version": "9.0.5",
+              "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+              "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+              "dev": true,
+              "requires": {
+                "cli-truncate": "^5.0.0",
+                "colorette": "^2.0.20",
+                "eventemitter3": "^5.0.1",
+                "log-update": "^6.1.0",
+                "rfdc": "^1.4.1",
+                "wrap-ansi": "^9.0.0"
+              }
+            },
+            "log-update": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+              "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+              "dev": true,
+              "requires": {
+                "ansi-escapes": "^7.0.0",
+                "cli-cursor": "^5.0.0",
+                "slice-ansi": "^7.1.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+              },
+              "dependencies": {
+                "slice-ansi": {
+                  "version": "7.1.2",
+                  "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+                  "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+                  "dev": true,
+                  "requires": {
+                    "ansi-styles": "^6.2.1",
+                    "is-fullwidth-code-point": "^5.0.0"
+                  }
+                }
+              }
+            },
+            "qs": {
+              "version": "6.15.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+              "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+              "dev": true,
+              "requires": {
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
+              }
+            },
+            "restore-cursor": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+              "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+              "dev": true,
+              "requires": {
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
+              },
+              "dependencies": {
+                "onetime": {
+                  "version": "7.0.0",
+                  "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+                  "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+                  "dev": true,
+                  "requires": {
+                    "mimic-function": "^5.0.0"
+                  }
+                },
+                "signal-exit": {
+                  "version": "4.1.0",
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+                  "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+                  "dev": true
+                }
+              }
+            },
+            "rfdc": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+              "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+              "dev": true
+            },
+            "side-channel": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+              "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+              "dev": true,
+              "requires": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+              }
+            },
+            "side-channel-list": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+              "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+              "dev": true,
+              "requires": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+              }
+            },
+            "slice-ansi": {
+              "version": "8.0.0",
+              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+              "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^6.2.3",
+                "is-fullwidth-code-point": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+              "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^6.2.2"
+              }
+            },
+            "supports-color": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            },
+            "wrap-ansi": {
+              "version": "9.0.2",
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+              "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "7.2.0",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+                  "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+                  "dev": true,
+                  "requires": {
+                    "emoji-regex": "^10.3.0",
+                    "get-east-asian-width": "^1.0.0",
+                    "strip-ansi": "^7.1.0"
+                  }
+                }
+              }
+            },
+            "yauzl": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+              "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+              "dev": true,
+              "requires": {
+                "pend": "~1.2.0"
+              }
+            }
           }
         },
         "buildkite-test-collector-jasmine-example": {
@@ -15250,10 +15632,6 @@
             "buildkite-test-collector": "file:../..",
             "vitest": "^4.1.0"
           }
-        },
-        "cachedir": {
-          "version": "2.3.0",
-          "dev": true
         },
         "call-bind-apply-helpers": {
           "version": "1.0.2",
@@ -15310,10 +15688,6 @@
           "version": "1.0.2",
           "dev": true
         },
-        "check-more-types": {
-          "version": "2.24.0",
-          "dev": true
-        },
         "chokidar": {
           "version": "3.5.3",
           "dev": true,
@@ -15339,35 +15713,6 @@
         "cjs-module-lexer": {
           "version": "1.2.3",
           "dev": true
-        },
-        "clean-stack": {
-          "version": "2.2.0",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
-        "cli-table3": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
-          "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
-          "dev": true,
-          "requires": {
-            "@colors/colors": "1.5.0",
-            "string-width": "^4.2.0"
-          }
-        },
-        "cli-truncate": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "slice-ansi": "^3.0.0",
-            "string-width": "^4.2.0"
-          }
         },
         "cliui": {
           "version": "7.0.4",
@@ -15395,9 +15740,12 @@
         "color-name": {
           "version": "1.1.4"
         },
-        "colorette": {
-          "version": "2.0.19",
-          "dev": true
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.8",
@@ -16025,104 +16373,6 @@
             "which": "^2.0.1"
           }
         },
-        "cypress": {
-          "version": "14.2.0",
-          "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.0.tgz",
-          "integrity": "sha512-u7fuc9JEpSYLOdu8mzZDZ/JWsHUzR5pc8i1TeSqMz/bafXp+6IweMAeyphsEJ6/13qbB6nwTEY1m+GUAp6GqCQ==",
-          "dev": true,
-          "requires": {
-            "@cypress/request": "^3.0.7",
-            "@cypress/xvfb": "^1.2.4",
-            "@types/sinonjs__fake-timers": "8.1.1",
-            "@types/sizzle": "^2.3.2",
-            "arch": "^2.2.0",
-            "blob-util": "^2.0.2",
-            "bluebird": "^3.7.2",
-            "buffer": "^5.7.1",
-            "cachedir": "^2.3.0",
-            "chalk": "^4.1.0",
-            "check-more-types": "^2.24.0",
-            "ci-info": "^4.1.0",
-            "cli-cursor": "^3.1.0",
-            "cli-table3": "~0.6.5",
-            "commander": "^6.2.1",
-            "common-tags": "^1.8.0",
-            "dayjs": "^1.10.4",
-            "debug": "^4.3.4",
-            "enquirer": "^2.3.6",
-            "eventemitter2": "6.4.7",
-            "execa": "4.1.0",
-            "executable": "^4.1.1",
-            "extract-zip": "2.0.1",
-            "figures": "^3.2.0",
-            "fs-extra": "^9.1.0",
-            "getos": "^3.2.1",
-            "is-installed-globally": "~0.4.0",
-            "lazy-ass": "^1.6.0",
-            "listr2": "^3.8.3",
-            "lodash": "^4.17.21",
-            "log-symbols": "^4.0.0",
-            "minimist": "^1.2.8",
-            "ospath": "^1.2.2",
-            "pretty-bytes": "^5.6.0",
-            "process": "^0.11.10",
-            "proxy-from-env": "1.0.0",
-            "request-progress": "^3.0.0",
-            "semver": "^7.5.3",
-            "supports-color": "^8.1.1",
-            "tmp": "~0.2.3",
-            "tree-kill": "1.2.2",
-            "untildify": "^4.0.0",
-            "yauzl": "^2.10.0"
-          },
-          "dependencies": {
-            "ci-info": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-              "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
-              "dev": true
-            },
-            "execa": {
-              "version": "4.1.0",
-              "dev": true,
-              "requires": {
-                "cross-spawn": "^7.0.0",
-                "get-stream": "^5.0.0",
-                "human-signals": "^1.1.1",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.0",
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2",
-                "strip-final-newline": "^2.0.0"
-              }
-            },
-            "get-stream": {
-              "version": "5.2.0",
-              "dev": true,
-              "requires": {
-                "pump": "^3.0.0"
-              }
-            },
-            "human-signals": {
-              "version": "1.1.1",
-              "dev": true
-            },
-            "semver": {
-              "version": "7.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-              "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "8.1.1",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
         "dashdash": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -16233,12 +16483,11 @@
             "tapable": "^2.2.0"
           }
         },
-        "enquirer": {
-          "version": "2.3.6",
-          "dev": true,
-          "requires": {
-            "ansi-colors": "^4.1.1"
-          }
+        "environment": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+          "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+          "dev": true
         },
         "error-ex": {
           "version": "1.3.2",
@@ -16394,25 +16643,6 @@
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
           "dev": true
         },
-        "extract-zip": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "@types/yauzl": "^2.9.1",
-            "debug": "^4.1.1",
-            "get-stream": "^5.1.0",
-            "yauzl": "^2.10.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "5.2.0",
-              "dev": true,
-              "requires": {
-                "pump": "^3.0.0"
-              }
-            }
-          }
-        },
         "extsprintf": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -16432,26 +16662,6 @@
           "dev": true,
           "requires": {
             "bser": "2.1.1"
-          }
-        },
-        "fd-slicer": {
-          "version": "1.1.0",
-          "dev": true,
-          "requires": {
-            "pend": "~1.2.0"
-          }
-        },
-        "figures": {
-          "version": "3.2.0",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          },
-          "dependencies": {
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "dev": true
-            }
           }
         },
         "fill-range": {
@@ -16539,6 +16749,12 @@
           "version": "2.0.5",
           "dev": true
         },
+        "get-east-asian-width": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+          "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+          "dev": true
+        },
         "get-intrinsic": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -16572,13 +16788,6 @@
         "get-stream": {
           "version": "6.0.1",
           "dev": true
-        },
-        "getos": {
-          "version": "3.2.1",
-          "dev": true,
-          "requires": {
-            "async": "^3.2.0"
-          }
         },
         "getpass": {
           "version": "0.1.7",
@@ -16657,6 +16866,24 @@
           "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
           "requires": {
             "has-symbols": "^1.0.3"
+          }
+        },
+        "hasha": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+          "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+          "dev": true,
+          "requires": {
+            "is-stream": "^2.0.0",
+            "type-fest": "^0.8.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
           }
         },
         "hasown": {
@@ -16750,10 +16977,6 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "4.0.0",
           "dev": true
         },
         "inflight": {
@@ -18068,10 +18291,6 @@
           "version": "3.0.3",
           "dev": true
         },
-        "lazy-ass": {
-          "version": "1.6.0",
-          "dev": true
-        },
         "leven": {
           "version": "3.1.0",
           "dev": true
@@ -18177,20 +18396,6 @@
           "version": "1.2.4",
           "dev": true
         },
-        "listr2": {
-          "version": "3.14.0",
-          "dev": true,
-          "requires": {
-            "cli-truncate": "^2.1.0",
-            "colorette": "^2.0.16",
-            "log-update": "^4.0.0",
-            "p-map": "^4.0.0",
-            "rfdc": "^1.3.0",
-            "rxjs": "^7.5.1",
-            "through": "^2.3.8",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
         "loader-runner": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -18223,36 +18428,6 @@
           "requires": {
             "chalk": "^4.1.0",
             "is-unicode-supported": "^0.1.0"
-          }
-        },
-        "log-update": {
-          "version": "4.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^4.3.0",
-            "cli-cursor": "^3.1.0",
-            "slice-ansi": "^4.0.0",
-            "wrap-ansi": "^6.2.0"
-          },
-          "dependencies": {
-            "slice-ansi": {
-              "version": "4.0.0",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.0.0",
-                "astral-regex": "^2.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
-              }
-            },
-            "wrap-ansi": {
-              "version": "6.2.0",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-              }
-            }
           }
         },
         "loose-envify": {
@@ -18325,6 +18500,12 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
+          "dev": true
+        },
+        "mimic-function": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+          "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
           "dev": true
         },
         "minimatch": {
@@ -18575,13 +18756,6 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
-          }
-        },
-        "p-map": {
-          "version": "4.0.0",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
           }
         },
         "p-try": {
@@ -18897,18 +19071,6 @@
           "version": "1.1.1",
           "dev": true
         },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "dev": true,
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "rfdc": {
-          "version": "1.3.0",
-          "dev": true
-        },
         "rimraf": {
           "version": "3.0.2",
           "dev": true,
@@ -18939,13 +19101,6 @@
             "@rolldown/binding-win32-arm64-msvc": "1.0.3",
             "@rolldown/binding-win32-x64-msvc": "1.0.3",
             "@rolldown/pluginutils": "^1.0.0"
-          }
-        },
-        "rxjs": {
-          "version": "7.8.0",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
           }
         },
         "safe-buffer": {
@@ -19061,15 +19216,6 @@
           "version": "3.0.0",
           "dev": true
         },
-        "slice-ansi": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "astral-regex": "^2.0.0",
-            "is-fullwidth-code-point": "^3.0.0"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "dev": true
@@ -19181,6 +19327,12 @@
           "version": "1.0.0",
           "dev": true
         },
+        "systeminformation": {
+          "version": "5.33.1",
+          "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.1.tgz",
+          "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
+          "dev": true
+        },
         "tapable": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -19234,7 +19386,7 @@
             "@jridgewell/trace-mapping": "^0.3.25",
             "jest-worker": "^27.4.5",
             "schema-utils": "^4.3.0",
-            "serialize-javascript": "^6.0.2",
+            "serialize-javascript": "^7.0.5",
             "terser": "^5.31.1"
           },
           "dependencies": {
@@ -19271,10 +19423,6 @@
         },
         "throttleit": {
           "version": "1.0.0",
-          "dev": true
-        },
-        "through": {
-          "version": "2.3.8",
           "dev": true
         },
         "tinybench": {
@@ -19371,7 +19519,8 @@
         },
         "tslib": {
           "version": "2.4.1",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
@@ -19705,14 +19854,6 @@
             }
           }
         },
-        "yauzl": {
-          "version": "2.10.0",
-          "dev": true,
-          "requires": {
-            "buffer-crc32": "~0.2.3",
-            "fd-slicer": "~1.1.0"
-          }
-        },
         "yocto-queue": {
           "version": "0.1.0",
           "dev": true
@@ -19727,10 +19868,388 @@
         "@babel/preset-react": "^7.18.6",
         "babel-loader": "^9.1.0",
         "buildkite-test-collector": "file:../..",
-        "cypress": "^14.2.0",
+        "cypress": "^15.20.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "webpack": "^5.75.0"
+      },
+      "dependencies": {
+        "@cypress/request": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.1.tgz",
+          "integrity": "sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~4.0.4",
+            "http-signature": "~1.4.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "performance-now": "^2.1.0",
+            "qs": "^6.15.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "^5.0.0",
+            "tunnel-agent": "^0.6.0"
+          }
+        },
+        "ansi-escapes": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+          "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+          "dev": true,
+          "requires": {
+            "environment": "^1.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+          "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+          "dev": true
+        },
+        "arch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+          "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
+          "dev": true
+        },
+        "cachedir": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+          "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+          "dev": true
+        },
+        "ci-info": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+          "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+          "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^5.0.0"
+          }
+        },
+        "cli-table3": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+          "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+          "dev": true,
+          "requires": {
+            "colors": "1.4.0",
+            "string-width": "^4.2.0"
+          }
+        },
+        "cli-truncate": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+          "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+          "dev": true,
+          "requires": {
+            "slice-ansi": "^8.0.0",
+            "string-width": "^8.2.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "8.2.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+              "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+              "dev": true,
+              "requires": {
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
+              }
+            }
+          }
+        },
+        "colorette": {
+          "version": "2.0.20",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+          "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+          "dev": true
+        },
+        "cypress": {
+          "version": "15.20.1",
+          "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.20.1.tgz",
+          "integrity": "sha512-7GV3O7vQQG+EVVv9BGs6lCHY49x25jVi/z1+zdjuuq/o3eZeDwmGPJpRYnOWeGvQxTCtkydXWHBPhV8xuGXPLg==",
+          "dev": true,
+          "requires": {
+            "@cypress/request": "^4.0.0",
+            "@cypress/xvfb": "^1.2.4",
+            "@types/sinonjs__fake-timers": "8.1.1",
+            "@types/sizzle": "^2.3.2",
+            "@types/tmp": "^0.2.3",
+            "arch": "^3.0.0",
+            "blob-util": "^2.0.2",
+            "bluebird": "^3.7.2",
+            "buffer": "^5.7.1",
+            "cachedir": "^2.4.0",
+            "chalk": "^4.1.0",
+            "ci-info": "^4.1.0",
+            "cli-table3": "0.6.1",
+            "commander": "^6.2.1",
+            "common-tags": "^1.8.0",
+            "dayjs": "^1.10.4",
+            "debug": "^4.3.4",
+            "eventemitter2": "6.4.7",
+            "execa": "4.1.0",
+            "executable": "^4.1.1",
+            "fs-extra": "^9.1.0",
+            "hasha": "5.2.2",
+            "is-installed-globally": "~0.4.0",
+            "listr2": "^9.0.5",
+            "lodash": "^4.17.23",
+            "log-symbols": "^4.0.0",
+            "minimist": "^1.2.8",
+            "ospath": "^1.2.2",
+            "pretty-bytes": "^5.6.0",
+            "process": "^0.11.10",
+            "proxy-from-env": "1.0.0",
+            "request-progress": "^3.0.0",
+            "supports-color": "^8.1.1",
+            "systeminformation": "^5.31.1",
+            "tmp": "~0.2.4",
+            "tree-kill": "1.2.2",
+            "untildify": "^4.0.0",
+            "yauzl": "^3.3.1"
+          }
+        },
+        "emoji-regex": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+          "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+          "dev": true
+        },
+        "eventemitter3": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+          "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+          "dev": true
+        },
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+          "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+          "dev": true,
+          "requires": {
+            "get-east-asian-width": "^1.3.1"
+          }
+        },
+        "listr2": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+          "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+          "dev": true,
+          "requires": {
+            "cli-truncate": "^5.0.0",
+            "colorette": "^2.0.20",
+            "eventemitter3": "^5.0.1",
+            "log-update": "^6.1.0",
+            "rfdc": "^1.4.1",
+            "wrap-ansi": "^9.0.0"
+          }
+        },
+        "log-update": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+          "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^7.0.0",
+            "cli-cursor": "^5.0.0",
+            "slice-ansi": "^7.1.0",
+            "strip-ansi": "^7.1.0",
+            "wrap-ansi": "^9.0.0"
+          },
+          "dependencies": {
+            "slice-ansi": {
+              "version": "7.1.2",
+              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+              "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
+              }
+            }
+          }
+        },
+        "qs": {
+          "version": "6.15.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+          "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+          "dev": true,
+          "requires": {
+            "es-define-property": "^1.0.1",
+            "side-channel": "^1.1.1"
+          }
+        },
+        "restore-cursor": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+          "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^7.0.0",
+            "signal-exit": "^4.1.0"
+          },
+          "dependencies": {
+            "onetime": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+              "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+              "dev": true,
+              "requires": {
+                "mimic-function": "^5.0.0"
+              }
+            },
+            "signal-exit": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+              "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+              "dev": true
+            }
+          }
+        },
+        "rfdc": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+          "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+          "dev": true
+        },
+        "side-channel": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+          "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+          "dev": true,
+          "requires": {
+            "es-errors": "^1.3.0",
+            "object-inspect": "^1.13.4",
+            "side-channel-list": "^1.0.1",
+            "side-channel-map": "^1.0.1",
+            "side-channel-weakmap": "^1.0.2"
+          }
+        },
+        "side-channel-list": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+          "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+          "dev": true,
+          "requires": {
+            "es-errors": "^1.3.0",
+            "object-inspect": "^1.13.4"
+          }
+        },
+        "slice-ansi": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+          "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.2.3",
+            "is-fullwidth-code-point": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+          "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.2.2"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+          "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.2.1",
+            "string-width": "^7.0.0",
+            "strip-ansi": "^7.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+              "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+              }
+            }
+          }
+        },
+        "yauzl": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+          "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+          "dev": true,
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        }
       }
     },
     "buildkite-test-collector-jasmine-example": {
@@ -19781,10 +20300,6 @@
         "buildkite-test-collector": "file:../..",
         "vitest": "^4.1.0"
       }
-    },
-    "cachedir": {
-      "version": "2.3.0",
-      "dev": true
     },
     "call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -19841,10 +20356,6 @@
       "version": "1.0.2",
       "dev": true
     },
-    "check-more-types": {
-      "version": "2.24.0",
-      "dev": true
-    },
     "chokidar": {
       "version": "3.5.3",
       "dev": true,
@@ -19870,35 +20381,6 @@
     "cjs-module-lexer": {
       "version": "1.2.3",
       "dev": true
-    },
-    "clean-stack": {
-      "version": "2.2.0",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
-    "cli-table3": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
-      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
-      "dev": true,
-      "requires": {
-        "@colors/colors": "1.5.0",
-        "string-width": "^4.2.0"
-      }
-    },
-    "cli-truncate": {
-      "version": "2.1.0",
-      "dev": true,
-      "requires": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
-      }
     },
     "cliui": {
       "version": "7.0.4",
@@ -19926,9 +20408,12 @@
     "color-name": {
       "version": "1.1.4"
     },
-    "colorette": {
-      "version": "2.0.19",
-      "dev": true
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "optional": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -20556,104 +21041,6 @@
         "which": "^2.0.1"
       }
     },
-    "cypress": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.2.0.tgz",
-      "integrity": "sha512-u7fuc9JEpSYLOdu8mzZDZ/JWsHUzR5pc8i1TeSqMz/bafXp+6IweMAeyphsEJ6/13qbB6nwTEY1m+GUAp6GqCQ==",
-      "dev": true,
-      "requires": {
-        "@cypress/request": "^3.0.7",
-        "@cypress/xvfb": "^1.2.4",
-        "@types/sinonjs__fake-timers": "8.1.1",
-        "@types/sizzle": "^2.3.2",
-        "arch": "^2.2.0",
-        "blob-util": "^2.0.2",
-        "bluebird": "^3.7.2",
-        "buffer": "^5.7.1",
-        "cachedir": "^2.3.0",
-        "chalk": "^4.1.0",
-        "check-more-types": "^2.24.0",
-        "ci-info": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.5",
-        "commander": "^6.2.1",
-        "common-tags": "^1.8.0",
-        "dayjs": "^1.10.4",
-        "debug": "^4.3.4",
-        "enquirer": "^2.3.6",
-        "eventemitter2": "6.4.7",
-        "execa": "4.1.0",
-        "executable": "^4.1.1",
-        "extract-zip": "2.0.1",
-        "figures": "^3.2.0",
-        "fs-extra": "^9.1.0",
-        "getos": "^3.2.1",
-        "is-installed-globally": "~0.4.0",
-        "lazy-ass": "^1.6.0",
-        "listr2": "^3.8.3",
-        "lodash": "^4.17.21",
-        "log-symbols": "^4.0.0",
-        "minimist": "^1.2.8",
-        "ospath": "^1.2.2",
-        "pretty-bytes": "^5.6.0",
-        "process": "^0.11.10",
-        "proxy-from-env": "1.0.0",
-        "request-progress": "^3.0.0",
-        "semver": "^7.5.3",
-        "supports-color": "^8.1.1",
-        "tmp": "~0.2.3",
-        "tree-kill": "1.2.2",
-        "untildify": "^4.0.0",
-        "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "ci-info": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-          "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
-          "dev": true
-        },
-        "execa": {
-          "version": "4.1.0",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -20764,12 +21151,11 @@
         "tapable": "^2.2.0"
       }
     },
-    "enquirer": {
-      "version": "2.3.6",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^4.1.1"
-      }
+    "environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -20925,25 +21311,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
-    "extract-zip": {
-      "version": "2.0.1",
-      "dev": true,
-      "requires": {
-        "@types/yauzl": "^2.9.1",
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        }
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -20963,26 +21330,6 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
-      }
-    },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "pend": "~1.2.0"
-      }
-    },
-    "figures": {
-      "version": "3.2.0",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "dev": true
-        }
       }
     },
     "fill-range": {
@@ -21070,6 +21417,12 @@
       "version": "2.0.5",
       "dev": true
     },
+    "get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true
+    },
     "get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -21103,13 +21456,6 @@
     "get-stream": {
       "version": "6.0.1",
       "dev": true
-    },
-    "getos": {
-      "version": "3.2.1",
-      "dev": true,
-      "requires": {
-        "async": "^3.2.0"
-      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -21188,6 +21534,24 @@
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "requires": {
         "has-symbols": "^1.0.3"
+      }
+    },
+    "hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
       }
     },
     "hasown": {
@@ -21281,10 +21645,6 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "4.0.0",
       "dev": true
     },
     "inflight": {
@@ -22599,10 +22959,6 @@
       "version": "3.0.3",
       "dev": true
     },
-    "lazy-ass": {
-      "version": "1.6.0",
-      "dev": true
-    },
     "leven": {
       "version": "3.1.0",
       "dev": true
@@ -22708,20 +23064,6 @@
       "version": "1.2.4",
       "dev": true
     },
-    "listr2": {
-      "version": "3.14.0",
-      "dev": true,
-      "requires": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rfdc": "^1.3.0",
-        "rxjs": "^7.5.1",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "loader-runner": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -22754,36 +23096,6 @@
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
-      }
-    },
-    "log-update": {
-      "version": "4.0.0",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
-      },
-      "dependencies": {
-        "slice-ansi": {
-          "version": "4.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "astral-regex": "^2.0.0",
-            "is-fullwidth-code-point": "^3.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
       }
     },
     "loose-envify": {
@@ -22856,6 +23168,12 @@
     },
     "mimic-fn": {
       "version": "2.1.0",
+      "dev": true
+    },
+    "mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "dev": true
     },
     "minimatch": {
@@ -23106,13 +23424,6 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
-      }
-    },
-    "p-map": {
-      "version": "4.0.0",
-      "dev": true,
-      "requires": {
-        "aggregate-error": "^3.0.0"
       }
     },
     "p-try": {
@@ -23428,18 +23739,6 @@
       "version": "1.1.1",
       "dev": true
     },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "dev": true,
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "rfdc": {
-      "version": "1.3.0",
-      "dev": true
-    },
     "rimraf": {
       "version": "3.0.2",
       "dev": true,
@@ -23470,13 +23769,6 @@
         "@rolldown/binding-win32-arm64-msvc": "1.0.3",
         "@rolldown/binding-win32-x64-msvc": "1.0.3",
         "@rolldown/pluginutils": "^1.0.0"
-      }
-    },
-    "rxjs": {
-      "version": "7.8.0",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {
@@ -23592,15 +23884,6 @@
       "version": "3.0.0",
       "dev": true
     },
-    "slice-ansi": {
-      "version": "3.0.0",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      }
-    },
     "source-map": {
       "version": "0.6.1",
       "dev": true
@@ -23712,6 +23995,12 @@
       "version": "1.0.0",
       "dev": true
     },
+    "systeminformation": {
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.1.tgz",
+      "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
+      "dev": true
+    },
     "tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -23765,7 +24054,7 @@
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": "^7.0.5",
         "terser": "^5.31.1"
       },
       "dependencies": {
@@ -23802,10 +24091,6 @@
     },
     "throttleit": {
       "version": "1.0.0",
-      "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
       "dev": true
     },
     "tinybench": {
@@ -23902,7 +24187,8 @@
     },
     "tslib": {
       "version": "2.4.1",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -24234,14 +24520,6 @@
           "version": "6.3.0",
           "dev": true
         }
-      }
-    },
-    "yauzl": {
-      "version": "2.10.0",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "yocto-queue": {


### PR DESCRIPTION
## Summary

- upgrade the Cypress example from 14.2.0 to 15.20.1
- remove the vulnerable `extract-zip@2.0.1` transitive dependency
- resolve Dependabot alert [#144](https://github.com/buildkite/test-collector-javascript/security/dependabot/144) / [GHSA-jmr9-qjv8-65gv](https://github.com/advisories/GHSA-jmr9-qjv8-65gv)

Linear: [TE-6674](https://linear.app/buildkite/issue/TE-6674)

## Validation

- `npx jest e2e/cypress.test.js --runInBand` (5 tests passed)
- targeted unit tests (30 tests passed)
- `npm audit` no longer reports GHSA-jmr9-qjv8-65gv
- `npm ls cypress extract-zip --all` resolves Cypress 15.20.1 with no extract-zip dependency

The full suite also exercises unrelated Playwright and Vitest examples; those currently fail on the repository's Node 20.9.0 because the existing Vite 8 lockfile requires Node 20.19 or newer.